### PR TITLE
Edit group with incremental search

### DIFF
--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -2,8 +2,6 @@ $(function() {
   var searched_user_list = $("#searched_user_list");
   var add_user_list = $("#add_user_list")
   user_ids = [$(".current_user_id").val().toString()];
-  add_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
-  remove_button = '<a href="javascript:void(0)" class="remove_button add_remove_button" >削除</a>'
 
   function appendSearchedUserList(users) {
     $.each(users,
@@ -21,20 +19,32 @@ $(function() {
     );
   };
 
-  function appendAddUserList(user_name, user_id) {
-    var searched_user = '<div class="searched_user">' + user_name + '</div>'
-    var user_id = '<input type="hidden" id="user_id" name="group[user_ids][]" value="' + user_id + '">'
-    add_user_list.append( $('<li class="box">').append(searched_user, user_id, remove_button) )
+  function appendAddUserList(users) {
+    $.each(users,
+      function(index, user) {
+        if ( !(user_ids.includes( user.id.toString() )) ) {
+        var user_data = $(
+          '<li class="box">' +
+            '<div class="searched_user">' + user.name + '</div>' +
+            '<input type="hidden" id="user_id" name="group[user_ids][]" value="' + user.id + '">' +
+            '<a href="javascript:void(0)" class="remove_button add_remove_button">削除</a>' +
+          '</li>' );
+        add_user_list.append(user_data);
+        };
+      }
+    );
   };
 
   $('body').on('click', '.add_remove_button' , function() {
     if ( $(this).hasClass('add_button')) {
       add_user_list.append($(this).parent());
       $(this).prev().attr('name', 'group[user_ids][]');
+      var remove_button = '<a href="javascript:void(0)" class="remove_button add_remove_button" >削除</a>'
       $(this).parent().append(remove_button);
     }else {
       searched_user_list.append($(this).parent());
       $(this).prev().attr('name', '')
+      var add_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
       $(this).parent().append(add_button);
     }
     $(this).remove();
@@ -59,7 +69,9 @@ $(function() {
     })
     .done(function(users) {
       $("#searched_user_list .box").remove();
+
       appendSearchedUserList(users);
+      
       if (input_text.length === 0) {
         $("#searched_user_list .box").remove();
       };
@@ -69,14 +81,8 @@ $(function() {
     });
   });
 
-  // ↓↓ group edit用のコード ↓↓
-
+  // group edit の実装
   var group_users = gon.users
+  appendAddUserList(group_users)
 
-  $.each(group_users, function(i, user) {
-    if ( !( user_ids.includes( user.id.toString() )) ) {
-      user_ids.push(user.id.toString());
-      appendAddUserList(user.name, user.id)
-    };
-  });
 });

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -5,17 +5,20 @@ $(function() {
   add_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
   remove_button = '<a href="javascript:void(0)" class="remove_button add_remove_button" >削除</a>'
 
-  function appendSearchedUserList(user_name, user_id) {
-
-    if ( !(user_ids.includes( user_id.toString() )) ) {
-      var user_data = $(
-        '<li class="box">' +
-          '<div class="searched_user">' + user_name + '</div>' +
-          '<input type="hidden" id="user_id" name="" value="' + user_id + '">' +
-          '<a href="javascript:void(0)" class="add_button add_remove_button">追加</a>' +
-        '</li>' );
-      searched_user_list.append(user_data)
-    };
+  function appendSearchedUserList(users) {
+    $.each(users,
+      function(index, user) {
+        if ( !(user_ids.includes( user.id.toString() )) ) {
+        var user_data = $(
+          '<li class="box">' +
+            '<div class="searched_user">' + user.name + '</div>' +
+            '<input type="hidden" id="user_id" name="" value="' + user.id + '">' +
+            '<a href="javascript:void(0)" class="add_button add_remove_button">追加</a>' +
+          '</li>' );
+        searched_user_list.append(user_data);
+        };
+      }
+    );
   };
 
   function appendAddUserList(user_name, user_id) {
@@ -56,12 +59,7 @@ $(function() {
     })
     .done(function(users) {
       $("#searched_user_list .box").remove();
-      appendSearchedUserList(users)
-      $.each(users,
-        function(index, user) {
-          appendSearchedUserList(user.name, user.id);
-        }
-      )
+      appendSearchedUserList(users);
       if (input_text.length === 0) {
         $("#searched_user_list .box").remove();
       };

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -5,10 +5,10 @@ $(function() {
 
   function appendList(user_name, user_id) {
     if ( !(user_ids.includes( user_id.toString() )) ) {
-      var name = '<div class="searched_user">' + user_name + '</div>'
-      var id = '<input type="hidden" id="user_id" value="' + user_id + '">'
+      var user_name = '<div class="searched_user">' + user_name + '</div>'
+      var user_id = '<input type="hidden" id="user_id" value="' + user_id + '">'
       var remove_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
-      searched_user_list.append( $('<li class="box">').append(name, id, remove_button) )
+      searched_user_list.append( $('<li class="box">').append(user_name, user_id, remove_button) )
     };
   };
 

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -6,10 +6,15 @@ $(function() {
   remove_button = '<a href="javascript:void(0)" class="remove_button add_remove_button" >削除</a>'
 
   function appendSearchedUserList(user_name, user_id) {
+
     if ( !(user_ids.includes( user_id.toString() )) ) {
-      var user_name = '<div class="searched_user">' + user_name + '</div>'
-      var user_id = '<input type="hidden" id="user_id" name="" value="' + user_id + '">'
-      searched_user_list.append( $('<li class="box">').append(user_name, user_id, add_button) )
+      var user_data = $(
+        '<li class="box">' +
+          '<div class="searched_user">' + user_name + '</div>' +
+          '<input type="hidden" id="user_id" name="" value="' + user_id + '">' +
+          '<a href="javascript:void(0)" class="add_button add_remove_button">追加</a>' +
+        '</li>' );
+      searched_user_list.append(user_data)
     };
   };
 
@@ -51,6 +56,7 @@ $(function() {
     })
     .done(function(users) {
       $("#searched_user_list .box").remove();
+      appendSearchedUserList(users)
       $.each(users,
         function(index, user) {
           appendSearchedUserList(user.name, user.id);

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -56,6 +56,9 @@ $(function() {
           appendList(user.name, user.id);
         }
       )
+      if (input_text.length === 0) {
+        $("#searched_user_list .box").remove();
+      };
     })
     .fail(function(users) {
     });

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -2,46 +2,40 @@ $(function() {
   var searched_user_list = $("#searched_user_list");
   var add_user_list = $("#add_user_list")
   user_ids = [$(".current_user_id").val().toString()];
+  add_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
+  remove_button = '<a href="javascript:void(0)" class="remove_button add_remove_button" >削除</a>'
 
-  function appendList(user_name, user_id) {
+  function appendSearchedUserList(user_name, user_id) {
     if ( !(user_ids.includes( user_id.toString() )) ) {
       var user_name = '<div class="searched_user">' + user_name + '</div>'
       var user_id = '<input type="hidden" id="user_id" value="' + user_id + '">'
-      var remove_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
-      searched_user_list.append( $('<li class="box">').append(user_name, user_id, remove_button) )
+      searched_user_list.append( $('<li class="box">').append(user_name, user_id, add_button) )
     };
   };
 
   function appendAddUserList(user_name, user_id) {
-      var searched_user = $('<div class="searched_user">').append(user_name);
-      var user_id = $("<input>", {type: 'hidden', id: 'user_id', name: 'group[user_ids][]', value: user_id })
-      var remove_button = $('<a href="javascript:void(0)" class="remove_button add_remove_button" >').append("削除");
-      var box = $('<li class="box">').append(searched_user, user_id, remove_button);
-      add_user_list.append(box);
+    var searched_user = '<div class="searched_user">' + user_name + '</div>'
+    var user_id = '<input type="hidden" id="user_id" name: "group[user_ids][]" value="' + user_id + '">'
+    add_user_list.append( $('<li class="box">').append(searched_user, user_id, remove_button) )
   };
 
-  $('body').on('click', '.add_button', function() {
-    add_user_list.append($(this).parent());
-    $(this).prev().attr('name', 'group[user_ids][]');
-    var remove_button = $('<a href="javascript:void(0)" class="remove_button add_remove_button" >').append("削除");
-    $(this).parent().append(remove_button);
-    $(this).remove();
-  });
-
-  $('body').on('click', '.remove_button', function() {
-    searched_user_list.append($(this).parent());
-    $(this).prev().attr('name', '')
-    var add_button = $('<a href="javascript:void(0)" class="add_button add_remove_button" >').append("追加");
-    $(this).parent().append(add_button);
+  $('body').on('click', '.add_remove_button' , function() {
+    if ( $(this).hasClass('add_button')) {
+      add_user_list.append($(this).parent());
+      $(this).prev().attr('name', 'group[user_ids][]');
+      $(this).parent().append(remove_button);
+    }else {
+      searched_user_list.append($(this).parent());
+      $(this).prev().attr('name', '')
+      $(this).parent().append(add_button);
+    }
     $(this).remove();
   });
 
   // 削除、追加のボタンクリックの度に#add_user_listの中の #user_idを監視。そこにあるvalueを配列で取ってくる
   $('body').on('click', '.add_remove_button', function() {
     user_ids = $("#add_user_list #user_id").map(
-      function(){
-        return $(this).val();
-      }).get();
+      function(){ return $(this).val(); }).get();
   });
 
   // インクリメンタルサーチ部分
@@ -59,7 +53,7 @@ $(function() {
       $("#searched_user_list .box").remove();
       $.each(users,
         function(index, user) {
-          appendList(user.name, user.id);
+          appendSearchedUserList(user.name, user.id);
         }
       )
       if (input_text.length === 0) {

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -72,7 +72,7 @@ $(function() {
     });
   });
 
-  // ↓↓ group fix用のコード ↓↓
+  // ↓↓ group edit用のコード ↓↓
 
   var group_users = gon.users
 

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -61,6 +61,7 @@ $(function() {
       };
     })
     .fail(function(users) {
+      alert('検索が失敗しました。画面をリロードしてやり直してください。')
     });
   });
 

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -1,50 +1,55 @@
 $(function() {
   var searched_user_list = $("#searched_user_list");
   var add_user_list = $("#add_user_list")
-  user_ids = [$(".current_user_id").val().toString()];
+  user_ids = [];
 
-  function appendSearchedUserList(users) {
+  function appendSearchLoop(users) {
     $.each(users,
-      function(index, user) {
-        if ( !(user_ids.includes( user.id.toString() )) ) {
-        var user_data = $(
-          '<li class="box">' +
-            '<div class="searched_user">' + user.name + '</div>' +
-            '<input type="hidden" id="user_id" name="" value="' + user.id + '">' +
-            '<a href="javascript:void(0)" class="add_button add_remove_button">追加</a>' +
-          '</li>' );
-        searched_user_list.append(user_data);
+      function (index, user) {
+        if ( !( user_ids.includes(user.id.toString()) ) ) {
+          appendSeacrh(user.name, user.id)
         };
       }
     );
   };
 
-  function appendAddUserList(users) {
+  function appendAddLoop(users) {
     $.each(users,
-      function(index, user) {
-        if ( !(user_ids.includes( user.id.toString() )) ) {
-        var user_data = $(
-          '<li class="box">' +
-            '<div class="searched_user">' + user.name + '</div>' +
-            '<input type="hidden" id="user_id" name="group[user_ids][]" value="' + user.id + '">' +
-            '<a href="javascript:void(0)" class="remove_button add_remove_button">削除</a>' +
-          '</li>' );
-        add_user_list.append(user_data);
+      function (index, user) {
+        if ( !( user_ids.includes(user.id.toString()) ) ) {
+          appendAddList(user.name, user.id)
         };
       }
     );
   };
 
-  // box要素の上下移動 ＆ 追加、削除ボタンの相互書き換え
+  function appendSeacrhList(name, id){
+    var user_data = $(
+      '<li class="box">' +
+        '<div class="searched_user">' + name + '</div>' +
+        '<input type="hidden" id="user_id" name="" value="' + id + '">' +
+        '<a href="javascript:void(0)" class="add_button add_remove_button">追加</a>' +
+      '</li>' );
+    searched_user_list.append(user_data);
+  };
+
+  function appendAddList(name, id){
+    var user_data = $(
+      '<li class="box">' +
+        '<div class="searched_user">' + name + '</div>' +
+        '<input type="hidden" id="user_id" name="group[user_ids][]" value="' + id + '">' +
+        '<a href="javascript:void(0)" class="remove_button add_remove_button">追加</a>' +
+      '</li>' );
+    add_user_list.append(user_data);
+  };
+
   $('body').on('click', '.add_remove_button' , function() {
+    user_name = $(this).siblings('.searched_user').text()
+    user_id = $(this).siblings('#user_id').val()
     if ( $(this).hasClass('add_button')) {
-      add_user_list.append($(this).parent());
-      $(this).attr('class', 'remove_button add_remove_button').val('削除')
-      $(this).prev().attr('name', 'group[user_ids][]');
+      appendAddList(user_name, user_id)
     }else {
-      searched_user_list.append($(this).parent());
-      $(this).attr('class', 'add_button add_remove_button').val('追加')
-      $(this).prev().attr('name', '')
+      appendSeacrhList(user_name, user_id)
     }
   });
 
@@ -57,8 +62,7 @@ $(function() {
   // インクリメンタルサーチ部分
   $('#user-search-field').on('keyup', function(e) {
     e.preventDefault();
-    var textField = $('#user-search-field');
-    var input_text = textField.val();
+    var input_text = $('#user-search-field').val();
     $.ajax({
       type: 'GET',
       url: '/users',
@@ -67,9 +71,8 @@ $(function() {
     })
     .done(function(users) {
       $("#searched_user_list .box").remove();
-      appendSearchedUserList(users);
-      if (input_text.length === 0) {
-        $("#searched_user_list .box").remove();
+      if ( input_text.length !== 0 ) {
+        appendSearchLoop(users);
       };
     })
     .fail(function(users) {
@@ -79,6 +82,6 @@ $(function() {
 
   // group edit の実装
   var group_users = gon.users
-  appendAddUserList(group_users)
+  appendAddLoop(group_users)
 
 });

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -8,14 +8,14 @@ $(function() {
   function appendSearchedUserList(user_name, user_id) {
     if ( !(user_ids.includes( user_id.toString() )) ) {
       var user_name = '<div class="searched_user">' + user_name + '</div>'
-      var user_id = '<input type="hidden" id="user_id" value="' + user_id + '">'
+      var user_id = '<input type="hidden" id="user_id" name="" value="' + user_id + '">'
       searched_user_list.append( $('<li class="box">').append(user_name, user_id, add_button) )
     };
   };
 
   function appendAddUserList(user_name, user_id) {
     var searched_user = '<div class="searched_user">' + user_name + '</div>'
-    var user_id = '<input type="hidden" id="user_id" name: "group[user_ids][]" value="' + user_id + '">'
+    var user_id = '<input type="hidden" id="user_id" name="group[user_ids][]" value="' + user_id + '">'
     add_user_list.append( $('<li class="box">').append(searched_user, user_id, remove_button) )
   };
 

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -54,7 +54,13 @@ $(function() {
     $(this).parent().remove()
   });
 
-  // 削除、追加のボタンクリックの度に#add_user_listの中の #user_idを監視。そこにあるvalueを配列で取ってくる
+  // edit画面表示時に#add_user_listの中の#user_idのvalueを配列で取得、user_idsに格納。
+  $('body').ready(function() {
+    user_ids = $("#add_user_list #user_id").map(
+      function(){ return $(this).val(); }).get();
+  });
+
+  // 削除、追加ボタンクリック時に#add_user_listの中の #user_idのvalueを配列で取得、user_idsに格納。
   $('body').on('click', '.add_remove_button', function() {
     user_ids = $("#add_user_list #user_id").map(
       function(){ return $(this).val(); }).get();

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -1,7 +1,11 @@
 $(function() {
+  user_ids = [Number($('.current_user_id').val())];
   var searched_user_list = $("#searched_user_list");
   var add_user_list = $("#add_user_list")
-  user_ids = [Number($('.current_user_id').val())];
+
+  // group edit の実装
+  var group_users = gon.users
+  appendAddLoop(group_users)
 
   function appendSearchLoop(users) {
     $.each(users,
@@ -47,14 +51,14 @@ $(function() {
   };
 
   $('body').on('click', '.add_button' , function() {
-    name = $(this).siblings('.searched_user').text()
-    id = Number($(this).siblings('.user_id').val())
+    var name = $(this).siblings('.searched_user').text()
+    var id = Number($(this).siblings('.user_id').val())
     appendAddList(name, id)
     $(this).parent().remove()
   });
 
   $('body').on('click', '.remove_button' , function() {
-    id = Number($(this).siblings('.user_id').val())
+    var id = Number($(this).siblings('.user_id').val())
     // user_idsからidを削除
     user_ids = jQuery.grep(user_ids, function(user_id) { return user_id != id; });
     $(this).parent().remove()
@@ -80,9 +84,5 @@ $(function() {
       alert('検索が失敗しました。画面をリロードしてやり直してください。')
     });
   });
-
-  // group edit の実装
-  var group_users = gon.users
-  appendAddLoop(group_users)
 
 });

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -1,12 +1,12 @@
 $(function() {
   var searched_user_list = $("#searched_user_list");
   var add_user_list = $("#add_user_list")
-  user_ids = [];
+  user_ids = [Number($('.current_user_id').val())];
 
   function appendSearchLoop(users) {
     $.each(users,
       function (index, user) {
-        if ( !( user_ids.includes(user.id.toString()) ) ) {
+        if ( !( user_ids.includes(user.id) ) ) {
           appendSeacrhList(user.name, user.id)
         };
       }
@@ -16,7 +16,7 @@ $(function() {
   function appendAddLoop(users) {
     $.each(users,
       function (index, user) {
-        if ( !( user_ids.includes(user.id.toString()) ) ) {
+        if ( !( user_ids.includes(user.id) ) ) {
           appendAddList(user.name, user.id)
         };
       }
@@ -27,46 +27,40 @@ $(function() {
     var user_data = $(
       '<li class="box">' +
         '<div class="searched_user">' + name + '</div>' +
-        '<input type="hidden" id="user_id" name="" value="' + id + '">' +
-        '<a href="javascript:void(0)" class="add_button add_remove_button">追加</a>' +
+        '<input type="hidden" class="user_id" name="" value="' + id + '">' +
+        '<a href="javascript:void(0)" class="add_button">追加</a>' +
       '</li>' );
     searched_user_list.append(user_data);
+    // user_idsからidを削除
+    user_ids = jQuery.grep(user_ids, function(user_id) { return user_id != id; });
   };
 
   function appendAddList(name, id){
     var user_data = $(
       '<li class="box">' +
         '<div class="searched_user">' + name + '</div>' +
-        '<input type="hidden" id="user_id" name="group[user_ids][]" value="' + id + '">' +
-        '<a href="javascript:void(0)" class="remove_button add_remove_button">追加</a>' +
+        '<input type="hidden" class="user_id" name="group[user_ids][]" value="' + id + '">' +
+        '<a href="javascript:void(0)" class="remove_button">削除</a>' +
       '</li>' );
     add_user_list.append(user_data);
+    user_ids.push(id)
   };
 
-  $('body').on('click', '.add_remove_button' , function() {
-    user_name = $(this).siblings('.searched_user').text()
-    user_id = $(this).siblings('#user_id').val()
-    if ( $(this).hasClass('add_button')) {
-      appendAddList(user_name, user_id)
-    }else {
-      appendSeacrhList(user_name, user_id)
-    }
+  $('body').on('click', '.add_button' , function() {
+    name = $(this).siblings('.searched_user').text()
+    id = Number($(this).siblings('.user_id').val())
+    appendAddList(name, id)
     $(this).parent().remove()
   });
 
-  // edit画面表示時に#add_user_listの中の#user_idのvalueを配列で取得、user_idsに格納。
-  $('body').ready(function() {
-    user_ids = $("#add_user_list #user_id").map(
-      function(){ return $(this).val(); }).get();
+  $('body').on('click', '.remove_button' , function() {
+    id = Number($(this).siblings('.user_id').val())
+    // user_idsからidを削除
+    user_ids = jQuery.grep(user_ids, function(user_id) { return user_id != id; });
+    $(this).parent().remove()
   });
 
-  // 削除、追加ボタンクリック時に#add_user_listの中の #user_idのvalueを配列で取得、user_idsに格納。
-  $('body').on('click', '.add_remove_button', function() {
-    user_ids = $("#add_user_list #user_id").map(
-      function(){ return $(this).val(); }).get();
-  });
-
-  // インクリメンタルサーチ部分
+  // インクリメンタルサーチ
   $('#user-search-field').on('keyup', function(e) {
     e.preventDefault();
     var input_text = $('#user-search-field').val();

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -4,14 +4,13 @@ $(function() {
   user_ids = [$(".current_user_id").val().toString()];
 
   function appendList(user_name, user_id) {
-    if ( user_ids.includes(user_id.toString()) );
-    else {
+    if ( !(user_ids.includes( user_id.toString() )) ) {
       var searched_user = $('<div class="searched_user">').append(user_name);
       var user_id = $("<input>", {type: 'hidden', id: 'user_id', name: '', value: user_id })
       var add_button = $('<a href="javascript:void(0)" class="add_button add_remove_button" >').append("追加");
       var box = $('<li class="box">').append(searched_user, user_id, add_button);
       searched_user_list.append(box);
-    }
+    };
   };
 
   function appendAddUserList(user_name, user_id) {
@@ -77,10 +76,9 @@ $(function() {
   var group_users = gon.users
 
   $.each(group_users, function(i, user) {
-    if ( user_ids.includes(user.id.toString()) );
-    else {
+    if ( !( user_ids.includes( user.id.toString() )) ) {
       user_ids.push(user.id.toString());
       appendAddUserList(user.name, user.id)
-    }
+    };
   });
 });

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -3,15 +3,23 @@ $(function() {
   var add_user_list = $("#add_user_list")
   user_ids = [$(".current_user_id").val().toString()];
 
-  function appendList(user, user_id) {
+  function appendList(user_name, user_id) {
     if ( user_ids.includes(user_id.toString()) );
     else {
-      var searched_user = $('<div class="searched_user">').append(user);
+      var searched_user = $('<div class="searched_user">').append(user_name);
       var user_id = $("<input>", {type: 'hidden', id: 'user_id', name: '', value: user_id })
       var add_button = $('<a href="javascript:void(0)" class="add_button add_remove_button" >').append("追加");
       var box = $('<li class="box">').append(searched_user, user_id, add_button);
       searched_user_list.append(box);
     }
+  };
+
+  function appendAddUserList(user_name, user_id) {
+      var searched_user = $('<div class="searched_user">').append(user_name);
+      var user_id = $("<input>", {type: 'hidden', id: 'user_id', name: 'group[user_ids][]', value: user_id })
+      var remove_button = $('<a href="javascript:void(0)" class="remove_button add_remove_button" >').append("削除");
+      var box = $('<li class="box">').append(searched_user, user_id, remove_button);
+      add_user_list.append(box);
   };
 
   $('body').on('click', '.add_button', function() {
@@ -62,5 +70,17 @@ $(function() {
     })
     .fail(function(users) {
     });
+  });
+
+  // ↓↓ group fix用のコード ↓↓
+
+  var group_users = gon.users
+
+  $.each(group_users, function(i, user) {
+    if ( user_ids.includes(user.id.toString()) );
+    else {
+      user_ids.push(user.id.toString());
+      appendAddUserList(user.name, user.id)
+    }
   });
 });

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -7,7 +7,7 @@ $(function() {
     $.each(users,
       function (index, user) {
         if ( !( user_ids.includes(user.id.toString()) ) ) {
-          appendSeacrh(user.name, user.id)
+          appendSeacrhList(user.name, user.id)
         };
       }
     );
@@ -51,6 +51,7 @@ $(function() {
     }else {
       appendSeacrhList(user_name, user_id)
     }
+    $(this).parent().remove()
   });
 
   // 削除、追加のボタンクリックの度に#add_user_listの中の #user_idを監視。そこにあるvalueを配列で取ってくる

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -35,19 +35,17 @@ $(function() {
     );
   };
 
+  // box要素の上下移動 ＆ 追加、削除ボタンの相互書き換え
   $('body').on('click', '.add_remove_button' , function() {
     if ( $(this).hasClass('add_button')) {
       add_user_list.append($(this).parent());
+      $(this).attr('class', 'remove_button add_remove_button').val('削除')
       $(this).prev().attr('name', 'group[user_ids][]');
-      var remove_button = '<a href="javascript:void(0)" class="remove_button add_remove_button" >削除</a>'
-      $(this).parent().append(remove_button);
     }else {
       searched_user_list.append($(this).parent());
+      $(this).attr('class', 'add_button add_remove_button').val('追加')
       $(this).prev().attr('name', '')
-      var add_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
-      $(this).parent().append(add_button);
     }
-    $(this).remove();
   });
 
   // 削除、追加のボタンクリックの度に#add_user_listの中の #user_idを監視。そこにあるvalueを配列で取ってくる
@@ -69,9 +67,7 @@ $(function() {
     })
     .done(function(users) {
       $("#searched_user_list .box").remove();
-
       appendSearchedUserList(users);
-      
       if (input_text.length === 0) {
         $("#searched_user_list .box").remove();
       };

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -5,11 +5,10 @@ $(function() {
 
   function appendList(user_name, user_id) {
     if ( !(user_ids.includes( user_id.toString() )) ) {
-      var searched_user = $('<div class="searched_user">').append(user_name);
-      var user_id = $("<input>", {type: 'hidden', id: 'user_id', name: '', value: user_id })
-      var add_button = $('<a href="javascript:void(0)" class="add_button add_remove_button" >').append("追加");
-      var box = $('<li class="box">').append(searched_user, user_id, add_button);
-      searched_user_list.append(box);
+      var name = '<div class="searched_user">' + user_name + '</div>'
+      var id = '<input type="hidden" id="user_id" value="' + user_id + '">'
+      var remove_button = '<a href="javascript:void(0)" class="add_button add_remove_button" >追加</a>'
+      searched_user_list.append( $('<li class="box">').append(name, id, remove_button) )
     };
   };
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,6 +20,7 @@ class GroupsController < ApplicationController
   end
 
   def edit
+    gon.users = @group.users
   end
 
   def update

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    gon.users = @group.users
+    gon.users = @group.users.where.not(id: current_user.id)
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    users = User.where("name like '%" + params[:text] + "%'")
+    users = User.where.not(id: current_user.id).where("name like '%" + params[:text] + "%'")
     respond_to do |format|
       format.html
       format.json { render json: users }

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,5 +1,7 @@
 .chat-group-form
   %h1 チャットグループ編集
+  %input{name: "current_user_name", type: "hidden", value: current_user.name, class: 'current_user_name' }/
+  %input{name: "current_user_id", type: "hidden", value: current_user.id, class: 'current_user_id' }/
   = form_for @group do |f|
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
@@ -13,11 +15,18 @@
         .chat-group-form__search.clearfix
           = f.text_field :group_users, value: "", id: 'user-search-field', class: 'chat-group-form__input', placeholder: "追加したいユーザー名を入力してください"
         #user-search-result
+        %ul#searched_user_list
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
         = f.label :チャットメンバー, class: 'chat-group-form__label'
-        = collection_check_boxes( :group, :user_ids, User.all, :id, :name) do |t|
-          - t.label { t.check_box + t.text }
+        -# = collection_check_boxes( :group, :user_ids, User.all, :id, :name) do |t|
+        -#   - t.label { t.check_box + t.text }
+      .chat-group-form__field--right
+        %ul#add_user_list
+          %li.box
+            （ログイン中のユーザー）
+            .searched_user #{current_user.name}
+            %input#user_id{type: "hidden", name: 'group[user_ids][]', value: current_user.id}/
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,31 +1,4 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %input{name: "current_user_name", type: "hidden", value: current_user.name, class: 'current_user_name' }/
-  %input{name: "current_user_id", type: "hidden", value: current_user.id, class: 'current_user_id' }/
   = form_for @group do |f|
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input', placeholder: "グループ名を入力してください"
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :チャットメンバーを追加, class:'chat-group-form__label'
-      .chat-group-form__field--right
-        .chat-group-form__search.clearfix
-          = f.text_field :group_users, value: "", id: 'user-search-field', class: 'chat-group-form__input', placeholder: "追加したいユーザー名を入力してください"
-        #user-search-result
-        %ul#searched_user_list
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :チャットメンバー, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        %ul#add_user_list
-          %li.box
-            （ログイン中のユーザー）
-            .searched_user #{current_user.name}
-            %input#user_id{type: "hidden", name: 'group[user_ids][]', value: current_user.id}/
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.button :save, class: 'chat-group-form__action-btn', html: { data: { disable: { with: "Save" }}, name: "commit", type: "submit", value: "Save" }
+    = render partial: 'shared/form', locals: { f: f }

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -19,8 +19,6 @@
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
         = f.label :チャットメンバー, class: 'chat-group-form__label'
-        -# = collection_check_boxes( :group, :user_ids, User.all, :id, :name) do |t|
-        -#   - t.label { t.check_box + t.text }
       .chat-group-form__field--right
         %ul#add_user_list
           %li.box

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -22,8 +22,9 @@
       .chat-group-form__field--right
         %ul#add_user_list
           %li.box
-            %input#user_id{type: "hidden", name: 'group[user_ids][]', value: current_user.id}/
+            （ログイン中のユーザー）
             .searched_user #{current_user.name}
+            %input#user_id{type: "hidden", name: 'group[user_ids][]', value: current_user.id}/
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,31 +1,4 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %input{name: "current_user_name", type: "hidden", value: current_user.name, class: 'current_user_name' }/
-  %input{name: "current_user_id", type: "hidden", value: current_user.id, class: 'current_user_id' }/
   = form_for @group, html: {id: 'new_chat_group', class: 'new_chat_group'} do |f|
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input', placeholder: "グループ名を入力してください"
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :チャットメンバーを追加, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        .chat-group-form__search.clearfix
-        = f.text_field :group_users, value: "" , placeholder: "追加したいユーザー名を入力してください", id: 'user-search-field', class: 'chat-group-form__input'
-        #user-search-result
-        %ul#searched_user_list
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :チャットメンバー, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        %ul#add_user_list
-          %li.box
-            （ログイン中のユーザー）
-            .searched_user #{current_user.name}
-            %input#user_id{type: "hidden", name: 'group[user_ids][]', value: current_user.id}/
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.button :save, class: 'chat-group-form__action-btn', html: { data: { disable: { with: "Save" }}, name: "commit", type: "submit", value: "Save" }
+    = render partial: 'shared/form', locals: { f: f }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,7 @@
     - if alert
       %p.alert.alert-error.header= alert
     %title ChatSpace
+    = Gon::Base.render_data
     = stylesheet_link_tag    'application', media: 'all', data: { turbolinks: { track: true } }
     = javascript_include_tag 'application', data: { turbolinks: { track: true } }
     = csrf_meta_tags

--- a/app/views/shared/_form.html.haml
+++ b/app/views/shared/_form.html.haml
@@ -1,0 +1,28 @@
+%input{name: "current_user_name", type: "hidden", value: current_user.name, class: 'current_user_name' }/
+%input{name: "current_user_id", type: "hidden", value: current_user.id, class: 'current_user_id' }/
+.chat-group-form__field.clearfix
+  .chat-group-form__field--left
+    = f.label :name, class: 'chat-group-form__label'
+  .chat-group-form__field--right
+    = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input', placeholder: "グループ名を入力してください"
+.chat-group-form__field.clearfix
+  .chat-group-form__field--left
+    = f.label :チャットメンバーを追加, class: 'chat-group-form__label'
+  .chat-group-form__field--right
+    .chat-group-form__search.clearfix
+    = f.text_field :group_users, value: "", id: 'user-search-field', class: 'chat-group-form__input', placeholder: "追加したいユーザー名を入力してください"
+    #user-search-result
+    %ul#searched_user_list
+.chat-group-form__field.clearfix
+  .chat-group-form__field--left
+    = f.label :チャットメンバー, class: 'chat-group-form__label'
+  .chat-group-form__field--right
+    %ul#add_user_list
+      %li.box
+        （ログイン中のユーザー）
+        .searched_user #{current_user.name}
+        %input#user_id{type: "hidden", name: 'group[user_ids][]', value: current_user.id}/
+.chat-group-form__field.clearfix
+  .chat-group-form__field--left
+  .chat-group-form__field--right
+    = f.button :save, class: 'chat-group-form__action-btn', html: { data: { disable: { with: "Save" }}, name: "commit", type: "submit", value: "Save" }


### PR DESCRIPTION
# WHAT
### group editをする際に、インクリメンタルサーチでユーザーを探せるように実装

### - groups.js
- gonを用いて@group.usersを受け取る
- group.users、検索してきたusersをループでfunctionに渡す
- search_list, add_listに生htmlの形で追加
- add_button, remove_buttonの機能をリファクタリング
- user_idsの管理の仕方を変更

### - groups_controller
- gonを用いて@group.usersをjsへ渡す

### - edit.html.haml
- inputにcurrent_user.name と current_user.idを記述


- gem 'gon'を導入

# WHY
### groupのeditの簡易化