### PR TITLE
Set S3 & send images to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+.env
 
 /public/uploads/message/image
 /public/uploads/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,4 @@ gem 'carrierwave'
 gem 'rmagick'
 gem "mini_magick"
 gem 'fog'
+gem 'dotenv-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,4 @@ gem 'gon'
 gem 'carrierwave'
 gem 'rmagick'
 gem "mini_magick"
+gem 'fog'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.5)
     actioncable (5.0.1)
       actionpack (= 5.0.1)
       nio4r (~> 1.2)
@@ -67,6 +68,7 @@ GEM
     devise-i18n (1.1.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    excon (0.54.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -75,8 +77,136 @@ GEM
       railties (>= 3.0.0)
     faker (1.7.2)
       i18n (~> 0.5)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.38.0)
+      fog-aliyun (>= 0.1.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-cloudatcost (~> 0.1.0)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
+      fog-json
+      fog-local
+      fog-openstack
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-rackspace
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (1.2.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.11.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-cloudatcost (0.1.2)
+      fog-core (~> 1.36)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.43.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.1)
+      fog-core (~> 1.27)
+    fog-openstack (0.1.19)
+      fog-core (>= 1.40)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (3.0.0)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-rackspace (0.1.4)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-vsphere (1.7.0)
+      fog-core
+      rbvmomi (~> 1.9)
+    fog-xenserver (0.2.3)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
+    formatador (0.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     gon (6.1.0)
@@ -98,6 +228,8 @@ GEM
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
     i18n (0.7.0)
+    inflecto (0.0.2)
+    ipaddress (0.8.3)
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -160,6 +292,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    rbvmomi (1.9.4)
+      builder (~> 3.2)
+      json (>= 1.8)
+      nokogiri (~> 1.5)
+      trollop (~> 2.1)
     rdoc (4.3.0)
     request_store (1.3.2)
     responders (2.3.0)
@@ -208,6 +345,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    trollop (2.1.2)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -225,6 +363,7 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xml-simple (1.1.5)
 
 PLATFORMS
   ruby
@@ -237,6 +376,7 @@ DEPENDENCIES
   devise-i18n
   factory_girl_rails
   faker
+  fog
   font-awesome-rails
   gon
   haml-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,10 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.1.1)
     diff-lcs (1.2.5)
+    dotenv (2.2.0)
+    dotenv-rails (2.2.0)
+      dotenv (= 2.2.0)
+      railties (>= 3.2, < 5.1)
     erubis (2.7.0)
     excon (0.54.0)
     execjs (2.7.0)
@@ -374,6 +378,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   devise
   devise-i18n
+  dotenv-rails
   factory_girl_rails
   faker
   fog

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,12 +1,12 @@
 class ImageUploader < CarrierWave::Uploader::Base
-  
+
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -8,15 +8,15 @@ CarrierWave.configure do |config|
 
   case Rails.env
     when 'production'
-      config.fog_directory = 'koheikishimoto'
-      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/koheikishimoto'
+      config.fog_directory = 'chatspace-production'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/chatspace-production'
 
     when 'development'
-      config.fog_directory = 'kkishimotok-development'
-      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kkishimotok-development'
+      config.fog_directory = 'chatspace-development'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/chatspace-development'
 
     when 'test'
-      config.fog_directory = 'kkishimotok-test'
-      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kkishimotok-test'
+      config.fog_directory = 'chatspace-testtest'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/chatspace-testtest'
   end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,22 @@
+CarrierWave.configure do |config|
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    region: 'ap-northeast-1'
+  }
+
+  case Rails.env
+    when 'production'
+      config.fog_directory = 'koheikishimoto'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/koheikishimoto'
+
+    when 'development'
+      config.fog_directory = 'kkishimotok-development'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kkishimotok-development'
+
+    when 'test'
+      config.fog_directory = 'kkishimotok-test'
+      config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kkishimotok-test'
+  end
+end


### PR DESCRIPTION
# WHAT
- carrierwaveからS3へ画像を保存する設定
- AWSのkeyを.envに入れて安全に管理
- production, development, test環境でそれぞれS3の違うバケットに保存するように設定

### AWSに関して
- アカウント登録
- IAMの作成
- production, development, testそれぞれのバケットを作成

# WHY
- 画像をクラウドに保存し、利便性を確保するため